### PR TITLE
AWS NAT Gatewayを作成するCFnを作成

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2
+
+# Makefile
+[Makefile]
+indent_style = tab

--- a/natGateway.yaml
+++ b/natGateway.yaml
@@ -1,0 +1,17 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Nat Gateway
+
+Parameters:
+  SubnetPublic:
+    Description: Subnet Public.
+    Type: String
+  EIP:
+    Description: Elastic IP ADDR
+    Type: String
+
+Resources:
+  NatGateway:
+    Type: AWS::EC2::NatGateway
+    Properties:
+      AllocationId: !Ref EIP
+      SubnetId: !Ref SubnetPublic

--- a/network.yaml
+++ b/network.yaml
@@ -1,0 +1,98 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Parameters:
+  # SSH用キーペアの指定
+  KeyPair:
+    Description: KeyPair Name
+    Type: AWS::EC2::KeyPair::KeyName
+  # SSHを許可するIP
+  MyIP:
+    Description: My IP
+    Type:  String
+  AmiId:
+    Description: AMI ID
+    Type: AWS::EC2::Image::Id
+
+Resources:
+  FirstVPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+      Tags:
+      - Key: Name
+        Value: FirstVPC
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+      - Key: Name
+        Value: FirstVPC-IGW
+  AttachGateway:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref FirstVPC
+      InternetGatewayId: !Ref InternetGateway
+  FrontendRouteTable:
+    Type: AWS::EC2::RouteTable
+    DependsOn: AttachGateway
+    Properties:
+      VpcId: !Ref FirstVPC
+      Tags:
+      - Key: Name
+        Value: FirstVPC-FrontendRoute
+  FrontendRoute:
+    Type: AWS::EC2::Route
+    DependsOn: AttachGateway
+    Properties:
+      RouteTableId: !Ref FrontendRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+  FrontendSubnet:
+    Type: AWS::EC2::Subnet
+    DependsOn: AttachGateway
+    Properties:
+      CidrBlock: 10.0.1.0/24
+      MapPublicIpOnLaunch: 'true'
+      VpcId: !Ref FirstVPC
+      Tags:
+      - Key: Name
+        Value: FirstVPC-FrontendSubnet
+  FrontendSubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref FrontendSubnet
+      RouteTableId: !Ref FrontendRouteTable
+  FirstSecurityGroup:
+    Type: "AWS::EC2::SecurityGroup"
+    Properties:
+      GroupDescription: FirstSG
+      VpcId: !Ref FirstVPC
+      Tags:
+        - Key: 'Name'
+          Value: 'FirstSG'
+      SecurityGroupIngress:
+      - IpProtocol: tcp
+        FromPort: '22'
+        ToPort: '22'
+        CidrIp: !Ref MyIP
+  FirstEC2:
+    Type: AWS::EC2::Instance
+    Properties:
+      InstanceType: 't2.micro'
+      SecurityGroupIds: 
+        - !GetAtt FirstSecurityGroup.GroupId
+      SubnetId: !Ref FrontendSubnet
+      ImageId: !Ref AmiId
+      KeyName: !Ref KeyPair
+      Tags: 
+        - Key: Name
+          Value: FirstEC2
+  FirstEIP:
+    Type: "AWS::EC2::EIP"
+    Properties:
+      Domain: vpc
+  AttachEIP:
+    Type: AWS::EC2::EIPAssociation
+    Properties:
+      AllocationId: !GetAtt FirstEIP.AllocationId
+      InstanceId: !Ref FirstEC2


### PR DESCRIPTION
# 実装の目的/背景
- この変更に対する概要を記載
  - [サーバレスでNAT Gatewayの起動・停止を管理してみた【押忍！ソフト道場】 \| NTTテクノクロスブログ](https://www.ntt-tx.co.jp/column/dojo_aws_blog/20180411/)を参考にLambdaで消すようにした
  - しかし、CFnで管理しているなら、CircleCIと組み合わせればいけそうな気がする

# 備考
- 特になし